### PR TITLE
DOP-5007: Improve SearchProperty in Netlify Search Manifest Integration

### DIFF
--- a/search-manifest/.gitignore
+++ b/search-manifest/.gitignore
@@ -3,8 +3,6 @@ node_modules
 .cache
 dev-model.gql
 
-documents
-
 # Local Netlify folder
 .netlify
 

--- a/search-manifest/.gitignore
+++ b/search-manifest/.gitignore
@@ -3,6 +3,8 @@ node_modules
 .cache
 dev-model.gql
 
+documents
+
 # Local Netlify folder
 .netlify
 

--- a/search-manifest/package-lock.json
+++ b/search-manifest/package-lock.json
@@ -25,7 +25,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.14.9",
-        "vitest": "^2.0.3"
+        "vitest": "^2.0.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -1783,9 +1783,9 @@
       "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA=="
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.1.tgz",
-      "integrity": "sha512-lncuC4aHicncmbORnx+dUaAgzee9cm/PbIqgWz1PpXuwc+sa1Ct83tnqUDy/GFKleLiN7ZIeytM6KJ4cAn1SxA==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.2.tgz",
+      "integrity": "sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==",
       "cpu": [
         "arm"
       ],
@@ -1796,9 +1796,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.1.tgz",
-      "integrity": "sha512-F/tkdw0WSs4ojqz5Ovrw5r9odqzFjb5LIgHdHZG65dFI1lWTWRVy32KDJLKRISHgJvqUeUhdIvy43fX41znyDg==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.2.tgz",
+      "integrity": "sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==",
       "cpu": [
         "arm64"
       ],
@@ -1809,9 +1809,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.1.tgz",
-      "integrity": "sha512-vk+ma8iC1ebje/ahpxpnrfVQJibTMyHdWpOGZ3JpQ7Mgn/3QNHmPq7YwjZbIE7km73dH5M1e6MRRsnEBW7v5CQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.2.tgz",
+      "integrity": "sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==",
       "cpu": [
         "arm64"
       ],
@@ -1822,9 +1822,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.1.tgz",
-      "integrity": "sha512-IgpzXKauRe1Tafcej9STjSSuG0Ghu/xGYH+qG6JwsAUxXrnkvNHcq/NL6nz1+jzvWAnQkuAJ4uIwGB48K9OCGA==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.2.tgz",
+      "integrity": "sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==",
       "cpu": [
         "x64"
       ],
@@ -1835,9 +1835,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.1.tgz",
-      "integrity": "sha512-P9bSiAUnSSM7EmyRK+e5wgpqai86QOSv8BwvkGjLwYuOpaeomiZWifEos517CwbG+aZl1T4clSE1YqqH2JRs+g==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.2.tgz",
+      "integrity": "sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==",
       "cpu": [
         "arm"
       ],
@@ -1848,9 +1848,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.1.tgz",
-      "integrity": "sha512-5RnjpACoxtS+aWOI1dURKno11d7krfpGDEn19jI8BuWmSBbUC4ytIADfROM1FZrFhQPSoP+KEa3NlEScznBTyQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.2.tgz",
+      "integrity": "sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==",
       "cpu": [
         "arm"
       ],
@@ -1861,9 +1861,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.1.tgz",
-      "integrity": "sha512-8mwmGD668m8WaGbthrEYZ9CBmPug2QPGWxhJxh/vCgBjro5o96gL04WLlg5BA233OCWLqERy4YUzX3bJGXaJgQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.2.tgz",
+      "integrity": "sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==",
       "cpu": [
         "arm64"
       ],
@@ -1874,9 +1874,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.1.tgz",
-      "integrity": "sha512-dJX9u4r4bqInMGOAQoGYdwDP8lQiisWb9et+T84l2WXk41yEej8v2iGKodmdKimT8cTAYt0jFb+UEBxnPkbXEQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.2.tgz",
+      "integrity": "sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==",
       "cpu": [
         "arm64"
       ],
@@ -1887,9 +1887,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.1.tgz",
-      "integrity": "sha512-V72cXdTl4EI0x6FNmho4D502sy7ed+LuVW6Ym8aI6DRQ9hQZdp5sj0a2usYOlqvFBNKQnLQGwmYnujo2HvjCxQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.2.tgz",
+      "integrity": "sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1900,9 +1900,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.1.tgz",
-      "integrity": "sha512-f+pJih7sxoKmbjghrM2RkWo2WHUW8UbfxIQiWo5yeCaCM0TveMEuAzKJte4QskBp1TIinpnRcxkquY+4WuY/tg==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.2.tgz",
+      "integrity": "sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==",
       "cpu": [
         "riscv64"
       ],
@@ -1913,9 +1913,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.1.tgz",
-      "integrity": "sha512-qb1hMMT3Fr/Qz1OKovCuUM11MUNLUuHeBC2DPPAWUYYUAOFWaxInaTwTQmc7Fl5La7DShTEpmYwgdt2hG+4TEg==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.2.tgz",
+      "integrity": "sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==",
       "cpu": [
         "s390x"
       ],
@@ -1926,9 +1926,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.1.tgz",
-      "integrity": "sha512-7O5u/p6oKUFYjRbZkL2FLbwsyoJAjyeXHCU3O4ndvzg2OFO2GinFPSJFGbiwFDaCFc+k7gs9CF243PwdPQFh5g==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.2.tgz",
+      "integrity": "sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==",
       "cpu": [
         "x64"
       ],
@@ -1939,9 +1939,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.1.tgz",
-      "integrity": "sha512-pDLkYITdYrH/9Cv/Vlj8HppDuLMDUBmgsM0+N+xLtFd18aXgM9Nyqupb/Uw+HeidhfYg2lD6CXvz6CjoVOaKjQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.2.tgz",
+      "integrity": "sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==",
       "cpu": [
         "x64"
       ],
@@ -1952,9 +1952,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.1.tgz",
-      "integrity": "sha512-W2ZNI323O/8pJdBGil1oCauuCzmVd9lDmWBBqxYZcOqWD6aWqJtVBQ1dFrF4dYpZPks6F+xCZHfzG5hYlSHZ6g==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.2.tgz",
+      "integrity": "sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==",
       "cpu": [
         "arm64"
       ],
@@ -1965,9 +1965,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.1.tgz",
-      "integrity": "sha512-ELfEX1/+eGZYMaCIbK4jqLxO1gyTSOIlZr6pbC4SRYFaSIDVKOnZNMdoZ+ON0mrFDp4+H5MhwNC1H/AhE3zQLg==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.2.tgz",
+      "integrity": "sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==",
       "cpu": [
         "ia32"
       ],
@@ -1978,9 +1978,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.1.tgz",
-      "integrity": "sha512-yjk2MAkQmoaPYCSu35RLJ62+dz358nE83VfTePJRp8CG7aMg25mEJYpXFiD+NcevhX8LxD5OP5tktPXnXN7GDw==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.2.tgz",
+      "integrity": "sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==",
       "cpu": [
         "x64"
       ],
@@ -3581,13 +3581,13 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.3.tgz",
-      "integrity": "sha512-X6AepoOYePM0lDNUPsGXTxgXZAl3EXd0GYe/MZyVE4HzkUqyUVC6S3PrY5mClDJ6/7/7vALLMV3+xD/Ko60Hqg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.5.tgz",
+      "integrity": "sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "2.0.3",
-        "@vitest/utils": "2.0.3",
+        "@vitest/spy": "2.0.5",
+        "@vitest/utils": "2.0.5",
         "chai": "^5.1.1",
         "tinyrainbow": "^1.2.0"
       },
@@ -3596,9 +3596,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.0.3.tgz",
-      "integrity": "sha512-URM4GLsB2xD37nnTyvf6kfObFafxmycCL8un3OC9gaCs5cti2u+5rJdIflZ2fUJUen4NbvF6jCufwViAFLvz1g==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.0.5.tgz",
+      "integrity": "sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==",
       "dev": true,
       "dependencies": {
         "tinyrainbow": "^1.2.0"
@@ -3608,12 +3608,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.0.3.tgz",
-      "integrity": "sha512-EmSP4mcjYhAcuBWwqgpjR3FYVeiA4ROzRunqKltWjBfLNs1tnMLtF+qtgd5ClTwkDP6/DGlKJTNa6WxNK0bNYQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.0.5.tgz",
+      "integrity": "sha512-TfRfZa6Bkk9ky4tW0z20WKXFEwwvWhRY+84CnSEtq4+3ZvDlJyY32oNTJtM7AW9ihW90tX/1Q78cb6FjoAs+ig==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "2.0.3",
+        "@vitest/utils": "2.0.5",
         "pathe": "^1.1.2"
       },
       "funding": {
@@ -3621,12 +3621,12 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.0.3.tgz",
-      "integrity": "sha512-6OyA6v65Oe3tTzoSuRPcU6kh9m+mPL1vQ2jDlPdn9IQoUxl8rXhBnfICNOC+vwxWY684Vt5UPgtcA2aPFBb6wg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.0.5.tgz",
+      "integrity": "sha512-SgCPUeDFLaM0mIUHfaArq8fD2WbaXG/zVXjRupthYfYGzc8ztbFbu6dUNOblBG7XLMR1kEhS/DNnfCZ2IhdDew==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "2.0.3",
+        "@vitest/pretty-format": "2.0.5",
         "magic-string": "^0.30.10",
         "pathe": "^1.1.2"
       },
@@ -3635,9 +3635,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.0.3.tgz",
-      "integrity": "sha512-sfqyAw/ypOXlaj4S+w8689qKM1OyPOqnonqOc9T91DsoHbfN5mU7FdifWWv3MtQFf0lEUstEwR9L/q/M390C+A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.0.5.tgz",
+      "integrity": "sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^3.0.0"
@@ -3647,12 +3647,12 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.3.tgz",
-      "integrity": "sha512-c/UdELMuHitQbbc/EVctlBaxoYAwQPQdSNwv7z/vHyBKy2edYZaFgptE27BRueZB7eW8po+cllotMNTDpL3HWg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.5.tgz",
+      "integrity": "sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "2.0.3",
+        "@vitest/pretty-format": "2.0.5",
         "estree-walker": "^3.0.3",
         "loupe": "^3.1.1",
         "tinyrainbow": "^1.2.0"
@@ -9599,12 +9599,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.10",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+      "version": "0.30.11",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
+      "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/make-dir": {
@@ -10909,9 +10909,9 @@
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
     },
     "node_modules/postcss": {
-      "version": "8.4.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
-      "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
+      "version": "8.4.45",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.45.tgz",
+      "integrity": "sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==",
       "dev": true,
       "funding": [
         {
@@ -11584,9 +11584,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.1.tgz",
-      "integrity": "sha512-Elx2UT8lzxxOXMpy5HWQGZqkrQOtrVDDa/bm9l10+U4rQnVzbL/LgZ4NOM1MPIDyHk69W4InuYDF5dzRh4Kw1A==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.2.tgz",
+      "integrity": "sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -11599,22 +11599,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.18.1",
-        "@rollup/rollup-android-arm64": "4.18.1",
-        "@rollup/rollup-darwin-arm64": "4.18.1",
-        "@rollup/rollup-darwin-x64": "4.18.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.18.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.18.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.18.1",
-        "@rollup/rollup-linux-arm64-musl": "4.18.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.18.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.18.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.18.1",
-        "@rollup/rollup-linux-x64-gnu": "4.18.1",
-        "@rollup/rollup-linux-x64-musl": "4.18.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.18.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.18.1",
-        "@rollup/rollup-win32-x64-msvc": "4.18.1",
+        "@rollup/rollup-android-arm-eabi": "4.21.2",
+        "@rollup/rollup-android-arm64": "4.21.2",
+        "@rollup/rollup-darwin-arm64": "4.21.2",
+        "@rollup/rollup-darwin-x64": "4.21.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.21.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.21.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.21.2",
+        "@rollup/rollup-linux-arm64-musl": "4.21.2",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.21.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.21.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.21.2",
+        "@rollup/rollup-linux-x64-gnu": "4.21.2",
+        "@rollup/rollup-linux-x64-musl": "4.21.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.21.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.21.2",
+        "@rollup/rollup-win32-x64-msvc": "4.21.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -12150,9 +12150,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -12701,9 +12701,9 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.0.tgz",
-      "integrity": "sha512-q5nmENpTHgiPVd1cJDDc9cVoYN5x4vCvwT3FMilvKPKneCBZAxn2YWQjDF0UMcE9k0Cay1gBiDfTMU0g+mPMQA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -13123,14 +13123,14 @@
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
     "node_modules/vite": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.4.tgz",
-      "integrity": "sha512-Cw+7zL3ZG9/NZBB8C+8QbQZmR54GwqIz+WMI4b3JgdYJvX+ny9AjJXqkGQlDXSXRP9rP0B4tbciRMOVEKulVOA==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.3.tgz",
+      "integrity": "sha512-IH+nl64eq9lJjFqU+/yrRnrHPVTlgy42/+IzbOdaFDVlyLgI/wDlf+FCobXLX1cT0X5+7LMyH1mIy2xJdLfo8Q==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.21.3",
-        "postcss": "^8.4.39",
-        "rollup": "^4.13.0"
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -13149,6 +13149,7 @@
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
+        "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
         "terser": "^5.4.0"
@@ -13166,6 +13167,9 @@
         "sass": {
           "optional": true
         },
+        "sass-embedded": {
+          "optional": true
+        },
         "stylus": {
           "optional": true
         },
@@ -13178,9 +13182,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.0.3.tgz",
-      "integrity": "sha512-14jzwMx7XTcMB+9BhGQyoEAmSl0eOr3nrnn+Z12WNERtOvLN+d2scbRUvyni05rT3997Bg+rZb47NyP4IQPKXg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.0.5.tgz",
+      "integrity": "sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -13606,18 +13610,18 @@
       }
     },
     "node_modules/vitest": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.0.3.tgz",
-      "integrity": "sha512-o3HRvU93q6qZK4rI2JrhKyZMMuxg/JRt30E6qeQs6ueaiz5hr1cPj+Sk2kATgQzMMqsa2DiNI0TIK++1ULx8Jw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.0.5.tgz",
+      "integrity": "sha512-8GUxONfauuIdeSl5f9GTgVEpg5BTOlplET4WEDaeY2QBiN8wSm68vxN/tb5z405OwppfoCavnwXafiaYBC/xOA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
-        "@vitest/expect": "2.0.3",
-        "@vitest/pretty-format": "^2.0.3",
-        "@vitest/runner": "2.0.3",
-        "@vitest/snapshot": "2.0.3",
-        "@vitest/spy": "2.0.3",
-        "@vitest/utils": "2.0.3",
+        "@vitest/expect": "2.0.5",
+        "@vitest/pretty-format": "^2.0.5",
+        "@vitest/runner": "2.0.5",
+        "@vitest/snapshot": "2.0.5",
+        "@vitest/spy": "2.0.5",
+        "@vitest/utils": "2.0.5",
         "chai": "^5.1.1",
         "debug": "^4.3.5",
         "execa": "^8.0.1",
@@ -13628,8 +13632,8 @@
         "tinypool": "^1.0.0",
         "tinyrainbow": "^1.2.0",
         "vite": "^5.0.0",
-        "vite-node": "2.0.3",
-        "why-is-node-running": "^2.2.2"
+        "vite-node": "2.0.5",
+        "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
@@ -13643,8 +13647,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.0.3",
-        "@vitest/ui": "2.0.3",
+        "@vitest/browser": "2.0.5",
+        "@vitest/ui": "2.0.5",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/search-manifest/package.json
+++ b/search-manifest/package.json
@@ -27,6 +27,6 @@
   },
   "devDependencies": {
     "@types/node": "^20.14.9",
-    "vitest": "^2.0.3"
+    "vitest": "^2.0.5"
   }
 }

--- a/search-manifest/src/generateManifest/manifest.ts
+++ b/search-manifest/src/generateManifest/manifest.ts
@@ -8,7 +8,7 @@ export class Manifest {
   constructor(url: string = "", includeInGlobalSearch?: boolean) {
     this.url = url;
     this.documents = [];
-    if (includeInGlobalSearch) this.global = includeInGlobalSearch;
+    this.global = includeInGlobalSearch ?? false;
   }
 
   addDocument(document: ManifestEntry | null) {

--- a/search-manifest/src/generateManifest/manifest.ts
+++ b/search-manifest/src/generateManifest/manifest.ts
@@ -2,12 +2,11 @@ import { ManifestEntry } from "./manifestEntry";
 
 export class Manifest {
   url: string;
-  global: boolean;
+  global?: boolean;
   documents: ManifestEntry[];
 
-  constructor(includeInGlobalSearch: boolean, url: string = "") {
+  constructor(url: string = "", includeInGlobalSearch?: boolean) {
     this.url = url;
-    this.global = includeInGlobalSearch;
     this.documents = [];
   }
 

--- a/search-manifest/src/generateManifest/manifest.ts
+++ b/search-manifest/src/generateManifest/manifest.ts
@@ -5,10 +5,10 @@ export class Manifest {
   global?: boolean;
   documents: ManifestEntry[];
 
-  constructor(url: string = "", includeInGlobalSearch?: boolean) {
+  constructor(url: string = "", includeInGlobalSearch: boolean = false) {
     this.url = url;
     this.documents = [];
-    this.global = includeInGlobalSearch ?? false;
+    this.global = includeInGlobalSearch;
   }
 
   addDocument(document: ManifestEntry | null) {

--- a/search-manifest/src/generateManifest/manifest.ts
+++ b/search-manifest/src/generateManifest/manifest.ts
@@ -8,6 +8,7 @@ export class Manifest {
   constructor(url: string = "", includeInGlobalSearch?: boolean) {
     this.url = url;
     this.documents = [];
+    if (includeInGlobalSearch) this.global = includeInGlobalSearch;
   }
 
   addDocument(document: ManifestEntry | null) {

--- a/search-manifest/src/index.ts
+++ b/search-manifest/src/index.ts
@@ -52,13 +52,11 @@ integration.addBuildEventHandler(
 
     await run.command("unzip -o bundle.zip");
     const branch = netlifyConfig.build?.environment["BRANCH"];
-    console.log(branch);
 
     //use export function for uploading to S3
     const manifest = await generateManifest();
 
     console.log("=========== finished generating manifests ================");
-    //TODO: change how url is set
     const {
       searchProperty,
       url,

--- a/search-manifest/src/index.ts
+++ b/search-manifest/src/index.ts
@@ -53,6 +53,7 @@ integration.addBuildEventHandler(
 
     await run.command("unzip -o bundle.zip");
     const branch = netlifyConfig.build?.environment["BRANCH"];
+    console.log(branch);
 
     //use export function for uploading to S3
     const manifest = await generateManifest();

--- a/search-manifest/src/index.ts
+++ b/search-manifest/src/index.ts
@@ -12,7 +12,6 @@ import getProperties from "./uploadToAtlas/getProperties";
 const readdirAsync = promisify(readdir);
 
 const integration = new NetlifyIntegration();
-const ZIP_PATH = ``;
 
 export const generateManifest = async () => {
   // create Manifest object

--- a/search-manifest/src/index.ts
+++ b/search-manifest/src/index.ts
@@ -71,7 +71,7 @@ integration.addBuildEventHandler(
 
     //TODO: upload manifests to S3
 
-    //upload manifests to atlas
+    //uploads manifests to atlas
     console.log("=========== Uploading Manifests =================");
     try {
       await uploadManifest(manifest, searchProperty);

--- a/search-manifest/src/index.ts
+++ b/search-manifest/src/index.ts
@@ -17,7 +17,7 @@ const ZIP_PATH = ``;
 export const generateManifest = async () => {
   // create Manifest object
   //TODO: pass in global variable dependent
-  const manifest = new Manifest(true);
+  const manifest = new Manifest();
   console.log("=========== generating manifests ================");
   //go into documents directory and get list of file entries
 
@@ -59,8 +59,15 @@ integration.addBuildEventHandler(
 
     console.log("=========== finished generating manifests ================");
     //TODO: get manifest properties, change how url is set atm
-    const [searchProperty, url] = await getProperties();
+    const {
+      searchProperty,
+      url,
+      includeInGlobalSearch,
+    }: { searchProperty: string; url: string; includeInGlobalSearch: boolean } =
+      await getProperties(branch);
+
     manifest.url = url;
+    manifest.global = includeInGlobalSearch;
 
     //TODO: upload manifests to S3
 

--- a/search-manifest/src/index.ts
+++ b/search-manifest/src/index.ts
@@ -16,11 +16,10 @@ const ZIP_PATH = ``;
 
 export const generateManifest = async () => {
   // create Manifest object
-  //TODO: pass in global variable dependent
   const manifest = new Manifest();
   console.log("=========== generating manifests ================");
-  //go into documents directory and get list of file entries
 
+  //go into documents directory and get list of file entries
   const entries = await readdirAsync("documents", { recursive: true });
 
   const mappedEntries = entries.filter((fileName) => {
@@ -59,7 +58,7 @@ integration.addBuildEventHandler(
     const manifest = await generateManifest();
 
     console.log("=========== finished generating manifests ================");
-    //TODO: get manifest properties, change how url is set atm
+    //TODO: change how url is set
     const {
       searchProperty,
       url,

--- a/search-manifest/src/index.ts
+++ b/search-manifest/src/index.ts
@@ -16,6 +16,7 @@ const ZIP_PATH = ``;
 
 export const generateManifest = async () => {
   // create Manifest object
+  //TODO: pass in global variable dependent
   const manifest = new Manifest(true);
   console.log("=========== generating manifests ================");
   //go into documents directory and get list of file entries

--- a/search-manifest/src/uploadToAtlas/getProperties.ts
+++ b/search-manifest/src/uploadToAtlas/getProperties.ts
@@ -2,11 +2,11 @@ import { Db } from "mongodb";
 import { db } from "./searchConnector";
 import { DatabaseDocument } from "./types";
 
-// helper function to find the
+// helper function to find the associated branch
 const getBranch = (branches: any, branchName: string) => {
   for (let branchObj of branches) {
     //normalize for casing
-    if (branchObj.gitBranchName == branchName) {
+    if (branchObj.gitBranchName.toLowerCase() == branchName.toLowerCase()) {
       return branchObj;
     }
   }

--- a/search-manifest/src/uploadToAtlas/getProperties.ts
+++ b/search-manifest/src/uploadToAtlas/getProperties.ts
@@ -115,7 +115,7 @@ export const getProperties = async (branchName: string) => {
     console.error(`Error while getting docsets entry in Atlas ${e}`);
     throw e;
   }
-  teardown();
+  await teardown();
   return { searchProperty, url, includeInGlobalSearch };
 };
 

--- a/search-manifest/src/uploadToAtlas/getProperties.ts
+++ b/search-manifest/src/uploadToAtlas/getProperties.ts
@@ -1,19 +1,27 @@
-import { Db } from "mongodb";
+import { Collection, Db, Document, WithId } from "mongodb";
 import { db, teardown } from "./searchConnector";
-import { DatabaseDocument } from "./types";
+import {
+  DatabaseDocument,
+  DocsetsDocument,
+  ReposBranchesDocument,
+} from "./types";
+import { assertTrailingSlash } from "./utils";
 
 // helper function to find the associated branch
-export const getBranch = (branches: any, branchName: string) => {
-  for (let branchObj of branches) {
-    //normalize for casing
+const getBranch = (branches: any, branchName: string) => {
+  for (const branchObj of branches) {
     if (branchObj.gitBranchName.toLowerCase() == branchName.toLowerCase()) {
       return branchObj;
     }
   }
-  throw Error(`Current branch ${branchName} not found in repos branches entry`);
+  return undefined;
 };
 
-export const getProperties = async (branchName: string) => {
+export const _getBranch = (branches: any, branchName: string) => {
+  return getBranch(branches, branchName);
+};
+
+const getProperties = async (branchName: string) => {
   const ATLAS_CLUSTER0_URI = `mongodb+srv://${process.env.MONGO_ATLAS_USERNAME}:${process.env.MONGO_ATLAS_PASSWORD}@${process.env.MONGO_ATLAS_CLUSTER0_HOST}/?retryWrites=true&w=majority`;
   const SNOOTY_DB_NAME = `${process.env.MONGO_ATLAS_POOL_DB_NAME}`;
   const REPO_NAME = process.env.REPO_NAME;
@@ -26,22 +34,23 @@ export const getProperties = async (branchName: string) => {
   }
 
   let dbSession: Db;
-  let repos_branches;
+  let repos_branches: Collection<DatabaseDocument>;
   let docsets;
   let url: string = "";
   let searchProperty: string = "";
   let includeInGlobalSearch: boolean = false;
-  let repo: any;
-  let docsetRepo: any;
+  let repo: ReposBranchesDocument | null;
+  let docsetRepo: DocsetsDocument | null;
   let version: string;
 
   try {
-    //Conenct to database and get repos_branches, docsets collections
+    //connect to database and get repos_branches, docsets collections
     dbSession = await db(ATLAS_CLUSTER0_URI, SNOOTY_DB_NAME);
     repos_branches = dbSession.collection<DatabaseDocument>("repos_branches");
     docsets = dbSession.collection<DatabaseDocument>("docsets");
   } catch (e) {
     console.log("issue starting session for Snooty Pool Database", e);
+    throw new Error(`issue starting session for Snooty Pool Database ${e}`);
   }
 
   const query = {
@@ -49,30 +58,29 @@ export const getProperties = async (branchName: string) => {
   };
 
   try {
-    repo = await repos_branches
-      ?.find(query)
-      .project({
+    repo = await repos_branches.findOne<ReposBranchesDocument>(query, {
+      projection: {
         _id: 0,
         project: 1,
         search: 1,
         branches: 1,
         prodDeployable: 1,
         internalOnly: 1,
-      })
-      .toArray();
-    if (repo?.length) repo = repo[0];
-    else
+      },
+    });
+    if (!repo) {
       throw new Error(
         `Could not get repos_branches entry for repo ${REPO_NAME}, ${repo}, ${JSON.stringify(
           query
         )}`
       );
+    }
   } catch (e) {
     console.error(`Error while getting repos_branches entry in Atlas: ${e}`);
     throw e;
   }
 
-  const project = repo.project;
+  const { project } = repo;
 
   try {
     const {
@@ -87,7 +95,7 @@ export const getProperties = async (branchName: string) => {
     } = getBranch(repo.branches, branchName);
     includeInGlobalSearch = isStableBranch;
     version = urlSlug || gitBranchName;
-    searchProperty = `${project}-${version}`;
+    searchProperty = `${repo.search?.categoryName ?? project}-${version}`;
 
     if (
       repo.internalOnly ||
@@ -106,10 +114,12 @@ export const getProperties = async (branchName: string) => {
 
   try {
     const docsetsQuery = { project: { $eq: project } };
-    docsetRepo = await docsets?.find(docsetsQuery).toArray();
-    if (docsetRepo.length) {
+    docsetRepo = await docsets.findOne<DocsetsDocument>(docsetsQuery);
+    if (docsetRepo) {
       //TODO: change based on environment
-      url = docsetRepo[0].url?.dotcomprd + docsetRepo[0].prefix.dotcomprd;
+      url = assertTrailingSlash(
+        docsetRepo.url?.dotcomprd + docsetRepo.prefix.dotcomprd
+      );
     }
   } catch (e) {
     console.error(`Error while getting docsets entry in Atlas ${e}`);

--- a/search-manifest/src/uploadToAtlas/getProperties.ts
+++ b/search-manifest/src/uploadToAtlas/getProperties.ts
@@ -1,5 +1,5 @@
 import { Db } from "mongodb";
-import { db } from "./searchConnector";
+import { db, teardown } from "./searchConnector";
 import { DatabaseDocument } from "./types";
 
 // helper function to find the associated branch
@@ -115,6 +115,7 @@ export const getProperties = async (branchName: string) => {
     console.error(`Error while getting docsets entry in Atlas ${e}`);
     throw e;
   }
+  teardown();
   return { searchProperty, url, includeInGlobalSearch };
 };
 

--- a/search-manifest/src/uploadToAtlas/getProperties.ts
+++ b/search-manifest/src/uploadToAtlas/getProperties.ts
@@ -82,7 +82,7 @@ const getProperties = async (branchName: string) => {
       gitBranchName: string;
       isStableBranch: boolean;
       active: boolean;
-    } = getBranch(repo[0].branches, branchName);
+    } = getBranch(repo.branches, branchName);
     includeInGlobalSearch = isStableBranch;
     version = urlSlug || gitBranchName;
     searchProperty = `${project}-${version}`;
@@ -90,10 +90,10 @@ const getProperties = async (branchName: string) => {
     if (
       repo.internalOnly ||
       !repo.prodDeployable ||
-      !repo[0].search?.categoryTitle
+      !repo.search?.categoryTitle
     ) {
-      console.log(repo[0].prodDeployable);
-      console.log(repo[0].search?.categoryTitle);
+      console.log(repo.prodDeployable);
+      console.log(repo.search?.categoryTitle);
 
       //TODO: deletestaleproperties here potentially instead of throwing
       throw new Error(
@@ -109,7 +109,7 @@ const getProperties = async (branchName: string) => {
     const docsetsQuery = { project: { $eq: project } };
     docsetRepo = await docsets?.find(docsetsQuery).toArray();
     if (docsetRepo.length) {
-      url = docsetRepo[0].url.dotcomprd + docsetRepo[0].prefix.dotcomprd;
+      url = docsetRepo.url.dotcomprd + docsetRepo.prefix.dotcomprd;
     }
   } catch (e) {
     console.error(`Error while getting docsets entry in Atlas ${e}`);

--- a/search-manifest/src/uploadToAtlas/getProperties.ts
+++ b/search-manifest/src/uploadToAtlas/getProperties.ts
@@ -14,10 +14,8 @@ const getBranch = (branches: any, branchName: string) => {
   );
 };
 
-// get whether branch is stable as well - set global from this?
 const getProperties = async (branchName: string) => {
   const ATLAS_CLUSTER0_URI = `mongodb+srv://${process.env.MONGO_ATLAS_USERNAME}:${process.env.MONGO_ATLAS_PASSWORD}@${process.env.MONGO_ATLAS_CLUSTER0_HOST}/?retryWrites=true&w=majority`;
-  //TODO: change these teamwide env vars in Netlify UI when ready to move to prod
   const SNOOTY_DB_NAME = `${process.env.MONGO_ATLAS_POOL_DB_NAME}`;
   const REPO_NAME = process.env.REPO_NAME;
 
@@ -39,6 +37,7 @@ const getProperties = async (branchName: string) => {
   let version: string;
 
   try {
+    //Conenct to database and get repos_branches, docsets collections
     dbSession = await db(ATLAS_CLUSTER0_URI, SNOOTY_DB_NAME);
     repos_branches = dbSession.collection<DatabaseDocument>("repos_branches");
     docsets = dbSession.collection<DatabaseDocument>("docsets");
@@ -79,14 +78,9 @@ const getProperties = async (branchName: string) => {
       version = urlSlug || gitBranchName;
       searchProperty = `${project}-${version}`;
 
-      //TODO: check if repo, branch is active
       if (!repo[0].prodDeployable || !repo[0].search?.categoryTitle) {
-        //add operations with deletestaledocuments and deletestaleproperties
-        //return nothing because manifest can't be generated
-      } else if (!active) {
-        //version isn't active
-        //add operations with deletestaledocuments and deletestaleproperties
-        //return nothing because manifest shouldn't be generated
+        //TODO: deletestaleproperties here potentially
+        throw new Error("search manifest should not be generated for ");
       }
     } catch (e) {
       console.error(`Error while getting branch entry`);
@@ -104,8 +98,7 @@ const getProperties = async (branchName: string) => {
       throw e;
     }
   } else {
-    //return nothing because manifest can't be generated from empty repo entry
-    //throw error?
+    //TODO: return nothing because manifest can't be generated from empty repo entry, or throw error here?
   }
   return { searchProperty, url, includeInGlobalSearch };
 };

--- a/search-manifest/src/uploadToAtlas/getProperties.ts
+++ b/search-manifest/src/uploadToAtlas/getProperties.ts
@@ -109,7 +109,9 @@ const getProperties = async (branchName: string) => {
     const docsetsQuery = { project: { $eq: project } };
     docsetRepo = await docsets?.find(docsetsQuery).toArray();
     if (docsetRepo.length) {
-      url = docsetRepo.url.dotcomprd + docsetRepo.prefix.dotcomprd;
+      //TODO: change based on environment
+      console.log(docsetRepo.url, docsetRepo.prefix);
+      url = docsetRepo.url?.dotcomprd + docsetRepo.prefix?.dotcomprd;
     }
   } catch (e) {
     console.error(`Error while getting docsets entry in Atlas ${e}`);

--- a/search-manifest/src/uploadToAtlas/getProperties.ts
+++ b/search-manifest/src/uploadToAtlas/getProperties.ts
@@ -5,6 +5,7 @@ import { DatabaseDocument } from "./types";
 // helper function to find the
 const getBranch = (branches: any, branchName: string) => {
   for (let branchObj of branches) {
+    //normalize for casing
     if (branchObj.gitBranchName == branchName) {
       return branchObj;
     }
@@ -79,11 +80,16 @@ const getProperties = async (branchName: string) => {
       searchProperty = `${project}-${version}`;
 
       if (!repo[0].prodDeployable || !repo[0].search?.categoryTitle) {
+        console.log(repo[0].prodDeployable);
+        console.log(repo[0].search?.categoryTitle);
+
         //TODO: deletestaleproperties here potentially
-        throw new Error("search manifest should not be generated for ");
+        throw new Error(
+          `search manifest should not be generated for repo ${REPO_NAME}`
+        );
       }
     } catch (e) {
-      console.error(`Error while getting branch entry`);
+      console.error(`Error`);
       console.log(e);
     }
 

--- a/search-manifest/src/uploadToAtlas/getProperties.ts
+++ b/search-manifest/src/uploadToAtlas/getProperties.ts
@@ -110,8 +110,9 @@ const getProperties = async (branchName: string) => {
     docsetRepo = await docsets?.find(docsetsQuery).toArray();
     if (docsetRepo.length) {
       //TODO: change based on environment
-      console.log(docsetRepo[0].url, docsetRepo[0].prefix);
-      url = docsetRepo.url?.dotcomprd + docsetRepo.prefix?.dotcomprd;
+      console.log(docsetRepo[0].url.dotcomprd, docsetRepo[0].prefix.dotcomprd);
+      url = docsetRepo.url?.dotcomprd + docsetRepo.prefix.dotcomprd;
+      console.log(url);
     }
   } catch (e) {
     console.error(`Error while getting docsets entry in Atlas ${e}`);

--- a/search-manifest/src/uploadToAtlas/getProperties.ts
+++ b/search-manifest/src/uploadToAtlas/getProperties.ts
@@ -110,7 +110,7 @@ const getProperties = async (branchName: string) => {
     docsetRepo = await docsets?.find(docsetsQuery).toArray();
     if (docsetRepo.length) {
       //TODO: change based on environment
-      console.log(docsetRepo.url, docsetRepo.prefix);
+      console.log(docsetRepo[0].url, docsetRepo[0].prefix);
       url = docsetRepo.url?.dotcomprd + docsetRepo.prefix?.dotcomprd;
     }
   } catch (e) {

--- a/search-manifest/src/uploadToAtlas/getProperties.ts
+++ b/search-manifest/src/uploadToAtlas/getProperties.ts
@@ -49,16 +49,17 @@ export const getProperties = async (branchName: string) => {
   };
 
   try {
-    console.log(await repos_branches?.find().toArray());
-    repo = await repos_branches?.find(query).toArray();
-    //     .project({
-    //   _id: 0,
-    //   project: 1,
-    //   search: 1,
-    //   branches: 1,
-    //   prodDeployable: 1,
-    //   internalOnly: 1,
-    // })
+    repo = await repos_branches
+      ?.find(query)
+      .project({
+        _id: 0,
+        project: 1,
+        search: 1,
+        branches: 1,
+        prodDeployable: 1,
+        internalOnly: 1,
+      })
+      .toArray();
     if (repo?.length) repo = repo[0];
     else
       throw new Error(
@@ -93,11 +94,7 @@ export const getProperties = async (branchName: string) => {
       !repo.prodDeployable ||
       !repo.search?.categoryTitle
     ) {
-      console.log(repo.prodDeployable);
-      console.log(repo.search?.categoryTitle);
-
       //TODO: deletestaleproperties here potentially instead of throwing or returning
-
       throw new Error(
         `Search manifest should not be generated for repo ${REPO_NAME}`
       );
@@ -112,9 +109,7 @@ export const getProperties = async (branchName: string) => {
     docsetRepo = await docsets?.find(docsetsQuery).toArray();
     if (docsetRepo.length) {
       //TODO: change based on environment
-      console.log(docsetRepo[0].url.dotcomprd, docsetRepo[0].prefix.dotcomprd);
       url = docsetRepo[0].url?.dotcomprd + docsetRepo[0].prefix.dotcomprd;
-      console.log(url);
     }
   } catch (e) {
     console.error(`Error while getting docsets entry in Atlas ${e}`);

--- a/search-manifest/src/uploadToAtlas/getProperties.ts
+++ b/search-manifest/src/uploadToAtlas/getProperties.ts
@@ -2,8 +2,20 @@ import { Db } from "mongodb";
 import { db } from "./searchConnector";
 import { DatabaseDocument } from "./types";
 
+// helper function to find the
+const getBranch = (branches: any, branchName: string) => {
+  for (let branchObj of branches) {
+    if (branchObj.gitBranchName == branchName) {
+      return branchObj;
+    }
+  }
+  throw new Error(
+    `Current branch ${branchName} not found in repos branches entry`
+  );
+};
+
 // get whether branch is stable as well - set global from this?
-const getProperties = async () => {
+const getProperties = async (branchName: string) => {
   const ATLAS_CLUSTER0_URI = `mongodb+srv://${process.env.MONGO_ATLAS_USERNAME}:${process.env.MONGO_ATLAS_PASSWORD}@${process.env.MONGO_ATLAS_CLUSTER0_HOST}/?retryWrites=true&w=majority`;
   //TODO: change these teamwide env vars in Netlify UI when ready to move to prod
   const SNOOTY_DB_NAME = `${process.env.MONGO_ATLAS_POOL_DB_NAME}`;
@@ -21,8 +33,10 @@ const getProperties = async () => {
   let docsets;
   let url: string = "";
   let searchProperty: string = "";
+  let includeInGlobalSearch: boolean = false;
   let repo: any;
   let docsetRepo: any;
+  let version: string;
 
   try {
     dbSession = await db(ATLAS_CLUSTER0_URI, SNOOTY_DB_NAME);
@@ -37,15 +51,48 @@ const getProperties = async () => {
   };
 
   try {
-    repo = await repos_branches?.find(query).toArray();
+    repo = await repos_branches
+      ?.find(query)
+      .project({ _id: 0, project: 1, search: 1, branches: 1 })
+      .toArray();
   } catch (e) {
     console.error(`Error while getting repos_branches entry in Atlas: ${e}`);
     throw e;
   }
 
-  if (repo.length && repo[0].prodDeployable && repo[0].search) {
+  if (repo.length) {
     const project = repo[0].project;
-    searchProperty = repo[0].search.categoryTitle;
+
+    try {
+      const {
+        urlSlug,
+        gitBranchName,
+        isStableBranch,
+        active,
+      }: {
+        urlSlug: string;
+        gitBranchName: string;
+        isStableBranch: boolean;
+        active: boolean;
+      } = getBranch(repo[0].branches, branchName);
+      includeInGlobalSearch = isStableBranch;
+      version = urlSlug || gitBranchName;
+      searchProperty = `${project}-${version}`;
+
+      //TODO: check if repo, branch is active
+      if (!repo[0].prodDeployable || !repo[0].search?.categoryTitle) {
+        //add operations with deletestaledocuments and deletestaleproperties
+        //return nothing because manifest can't be generated
+      } else if (!active) {
+        //version isn't active
+        //add operations with deletestaledocuments and deletestaleproperties
+        //return nothing because manifest shouldn't be generated
+      }
+    } catch (e) {
+      console.error(`Error while getting branch entry`);
+      console.log(e);
+    }
+
     try {
       const docsetsQuery = { project: { $eq: project } };
       docsetRepo = await docsets?.find(docsetsQuery).toArray();
@@ -56,11 +103,11 @@ const getProperties = async () => {
       console.error(`Error while getting docsets entry in Atlas ${e}`);
       throw e;
     }
+  } else {
+    //return nothing because manifest can't be generated from empty repo entry
+    //throw error?
   }
-  //check that repos exists, only one repo
-  //TODO: make sure branch is active
-  //if any of this is not true add operations with deletestaledocuments and deletestaleproperties
-  return [searchProperty, url];
+  return { searchProperty, url, includeInGlobalSearch };
 };
 
 export default getProperties;

--- a/search-manifest/src/uploadToAtlas/getProperties.ts
+++ b/search-manifest/src/uploadToAtlas/getProperties.ts
@@ -10,9 +10,7 @@ export const getBranch = (branches: any, branchName: string) => {
       return branchObj;
     }
   }
-  throw new Error(
-    `Current branch ${branchName} not found in repos branches entry`
-  );
+  throw Error(`Current branch ${branchName} not found in repos branches entry`);
 };
 
 export const getProperties = async (branchName: string) => {
@@ -51,19 +49,23 @@ export const getProperties = async (branchName: string) => {
   };
 
   try {
-    repo = await repos_branches
-      ?.find(query)
-      .project({
-        _id: 0,
-        project: 1,
-        search: 1,
-        branches: 1,
-        prodDeployable: 1,
-        internalOnly: 1,
-      })
-      .toArray();
-    if (repo.length) repo = repo[0];
-    else throw new Error("Could not get repos_branches entry for repo");
+    console.log(await repos_branches?.find().toArray());
+    repo = await repos_branches?.find(query).toArray();
+    //     .project({
+    //   _id: 0,
+    //   project: 1,
+    //   search: 1,
+    //   branches: 1,
+    //   prodDeployable: 1,
+    //   internalOnly: 1,
+    // })
+    if (repo?.length) repo = repo[0];
+    else
+      throw new Error(
+        `Could not get repos_branches entry for repo ${REPO_NAME}, ${repo}, ${JSON.stringify(
+          query
+        )}`
+      );
   } catch (e) {
     console.error(`Error while getting repos_branches entry in Atlas: ${e}`);
     throw e;
@@ -94,14 +96,15 @@ export const getProperties = async (branchName: string) => {
       console.log(repo.prodDeployable);
       console.log(repo.search?.categoryTitle);
 
-      //TODO: deletestaleproperties here potentially instead of throwing
+      //TODO: deletestaleproperties here potentially instead of throwing or returning
+
       throw new Error(
         `Search manifest should not be generated for repo ${REPO_NAME}`
       );
     }
   } catch (e) {
-    console.error(`Error`);
-    console.log(e);
+    console.error(`Error`, e);
+    throw e;
   }
 
   try {

--- a/search-manifest/src/uploadToAtlas/getProperties.ts
+++ b/search-manifest/src/uploadToAtlas/getProperties.ts
@@ -111,7 +111,7 @@ const getProperties = async (branchName: string) => {
     if (docsetRepo.length) {
       //TODO: change based on environment
       console.log(docsetRepo[0].url.dotcomprd, docsetRepo[0].prefix.dotcomprd);
-      url = docsetRepo.url?.dotcomprd + docsetRepo.prefix.dotcomprd;
+      url = docsetRepo[0].url?.dotcomprd + docsetRepo[0].prefix.dotcomprd;
       console.log(url);
     }
   } catch (e) {

--- a/search-manifest/src/uploadToAtlas/getProperties.ts
+++ b/search-manifest/src/uploadToAtlas/getProperties.ts
@@ -3,7 +3,7 @@ import { db } from "./searchConnector";
 import { DatabaseDocument } from "./types";
 
 // helper function to find the associated branch
-const getBranch = (branches: any, branchName: string) => {
+export const getBranch = (branches: any, branchName: string) => {
   for (let branchObj of branches) {
     //normalize for casing
     if (branchObj.gitBranchName.toLowerCase() == branchName.toLowerCase()) {
@@ -15,7 +15,7 @@ const getBranch = (branches: any, branchName: string) => {
   );
 };
 
-const getProperties = async (branchName: string) => {
+export const getProperties = async (branchName: string) => {
   const ATLAS_CLUSTER0_URI = `mongodb+srv://${process.env.MONGO_ATLAS_USERNAME}:${process.env.MONGO_ATLAS_PASSWORD}@${process.env.MONGO_ATLAS_CLUSTER0_HOST}/?retryWrites=true&w=majority`;
   const SNOOTY_DB_NAME = `${process.env.MONGO_ATLAS_POOL_DB_NAME}`;
   const REPO_NAME = process.env.REPO_NAME;
@@ -76,7 +76,6 @@ const getProperties = async (branchName: string) => {
       urlSlug,
       gitBranchName,
       isStableBranch,
-      active,
     }: {
       urlSlug: string;
       gitBranchName: string;

--- a/search-manifest/src/uploadToAtlas/searchConnector.ts
+++ b/search-manifest/src/uploadToAtlas/searchConnector.ts
@@ -12,6 +12,10 @@ import * as mongodb from "mongodb";
 let dbInstance: Db;
 let client: mongodb.MongoClient;
 
+export const teardown = async () => {
+  await client.close();
+};
+
 // Handles memoization of db object, and initial connection logic if needs to be initialized
 export const db = async (uri: string, db_name: string) => {
   client = new mongodb.MongoClient(uri);

--- a/search-manifest/src/uploadToAtlas/types.ts
+++ b/search-manifest/src/uploadToAtlas/types.ts
@@ -4,9 +4,7 @@ import { ManifestEntry } from "../generateManifest/manifestEntry";
 export interface RefreshInfo {
   deleted: number;
   upserted: number;
-  errors: boolean;
   dateStarted: Date;
-  dateFinished: Date | null;
   elapsedMS: number | null;
 }
 

--- a/search-manifest/src/uploadToAtlas/types.ts
+++ b/search-manifest/src/uploadToAtlas/types.ts
@@ -1,3 +1,4 @@
+import { WithId } from "mongodb";
 import { ManifestEntry } from "../generateManifest/manifestEntry";
 
 export interface RefreshInfo {
@@ -9,6 +10,23 @@ export interface RefreshInfo {
   elapsedMS: number | null;
 }
 
+export interface DocsetsDocument extends WithId<Document> {
+  url: {
+    dev: string;
+    stg: string;
+    dotcomstg: string;
+    dotcomprd: string;
+    prd: string;
+  };
+  prefix: {
+    dev: string;
+    stg: string;
+    dotcomstg: string;
+    dotcomprd: string;
+    prd: string;
+  };
+}
+
 export interface DatabaseDocument extends ManifestEntry {
   url: string;
   lastModified: Date;
@@ -17,11 +35,18 @@ export interface DatabaseDocument extends ManifestEntry {
   includeInGlobalSearch: boolean;
 }
 
-export interface Branch {
-  branchName: string;
-  active: boolean;
-  urlSlug?: string | undefined;
-  search: string;
+export interface ReposBranchesDocument extends WithId<Document> {
   project: string;
+  search: any;
+  branches: any;
   prodDeployable: boolean;
+  internalOnly: boolean;
+}
+
+export interface BranchEntry {
+  name: string;
+  gitBranchName: string;
+  urlSlug: string;
+  isStableBranch: boolean;
+  active: boolean;
 }

--- a/search-manifest/src/uploadToAtlas/uploadManifest.ts
+++ b/search-manifest/src/uploadToAtlas/uploadManifest.ts
@@ -65,9 +65,7 @@ export const uploadManifest = async (
   const status: RefreshInfo = {
     deleted: 0,
     upserted: 0,
-    errors: false,
     dateStarted: new Date(),
-    dateFinished: null,
     elapsedMS: null,
   };
 
@@ -101,12 +99,12 @@ export const uploadManifest = async (
       status.deleted += bulkWriteStatus?.deletedCount ?? 0;
       status.upserted += bulkWriteStatus?.upsertedCount ?? 0;
     }
+    return status;
   } catch (e) {
     throw new Error(
       `Error writing upserts to Search.documents collection with error ${e}`
     );
   } finally {
     await teardown();
-    return status;
   }
 };

--- a/search-manifest/src/uploadToAtlas/uploadManifest.ts
+++ b/search-manifest/src/uploadToAtlas/uploadManifest.ts
@@ -20,13 +20,8 @@ const composeUpserts = async (
   const documents = manifest.documents;
   return documents.map((document) => {
     assert.strictEqual(typeof document.slug, "string");
-    // DOP-3545 and DOP-3585
-    // slug is possible to be empty string ''
     assert.ok(document.slug || document.slug === "");
 
-    // DOP-3962
-    // We need a slug field with no special chars for keyword search
-    // and exact match, e.g. no "( ) { } [ ] ^ “ ~ * ? : \ /" present
     document.strippedSlug = document.slug.replaceAll("/", "");
 
     const newDocument: DatabaseDocument = {

--- a/search-manifest/src/uploadToAtlas/uploadManifest.ts
+++ b/search-manifest/src/uploadToAtlas/uploadManifest.ts
@@ -29,11 +29,6 @@ const composeUpserts = async (
     // and exact match, e.g. no "( ) { } [ ] ^ “ ~ * ? : \ /" present
     document.strippedSlug = document.slug.replaceAll("/", "");
 
-    //don't need to sort facets first??
-    // if (document.facets) {
-    //   document.facets = sortFacetsObject(document.facets, trieFacets);
-    // }
-
     const newDocument: DatabaseDocument = {
       ...document,
       lastModified: lastModified,
@@ -110,6 +105,6 @@ export const uploadManifest = async (
     status.deleted += bulkWriteStatus?.deletedCount ?? 0;
     status.upserted += bulkWriteStatus?.upsertedCount ?? 0;
   }
-  teardown();
+  await teardown();
   return status;
 };

--- a/search-manifest/src/uploadToAtlas/uploadManifest.ts
+++ b/search-manifest/src/uploadToAtlas/uploadManifest.ts
@@ -93,13 +93,20 @@ export const uploadManifest = async (
   assert.strictEqual(typeof hash, "string");
   assert.ok(hash);
 
-  if (operations.length > 0) {
-    const bulkWriteStatus = await documentsColl?.bulkWrite(operations, {
-      ordered: false,
-    });
-    status.deleted += bulkWriteStatus?.deletedCount ?? 0;
-    status.upserted += bulkWriteStatus?.upsertedCount ?? 0;
+  try {
+    if (operations.length > 0) {
+      const bulkWriteStatus = await documentsColl?.bulkWrite(operations, {
+        ordered: false,
+      });
+      status.deleted += bulkWriteStatus?.deletedCount ?? 0;
+      status.upserted += bulkWriteStatus?.upsertedCount ?? 0;
+    }
+  } catch (e) {
+    throw new Error(
+      `Error writing upserts to Search.documents collection with error ${e}`
+    );
+  } finally {
+    await teardown();
+    return status;
   }
-  await teardown();
-  return status;
 };

--- a/search-manifest/src/uploadToAtlas/uploadManifest.ts
+++ b/search-manifest/src/uploadToAtlas/uploadManifest.ts
@@ -103,9 +103,9 @@ export const uploadManifest = async (
 
   console.info(`Starting transaction`);
   console.log("global value:", manifest.global, typeof manifest.global);
-  // assert.strictEqual(typeof manifest.global, "boolean");
-  // assert.strictEqual(typeof hash, "string");
-  // assert.ok(hash);
+  assert.strictEqual(typeof manifest.global, "boolean");
+  assert.strictEqual(typeof hash, "string");
+  assert.ok(hash);
 
   if (operations.length > 0) {
     const bulkWriteStatus = await documentsColl?.bulkWrite(operations, {

--- a/search-manifest/src/uploadToAtlas/uploadManifest.ts
+++ b/search-manifest/src/uploadToAtlas/uploadManifest.ts
@@ -99,7 +99,6 @@ export const uploadManifest = async (
   //check property types
 
   console.info(`Starting transaction`);
-  console.log("global value:", manifest.global, typeof manifest.global);
   assert.strictEqual(typeof manifest.global, "boolean");
   assert.strictEqual(typeof hash, "string");
   assert.ok(hash);

--- a/search-manifest/src/uploadToAtlas/uploadManifest.ts
+++ b/search-manifest/src/uploadToAtlas/uploadManifest.ts
@@ -104,7 +104,6 @@ export const uploadManifest = async (
   console.info(`Starting transaction`);
   console.log(manifest.global);
   assert.strictEqual(typeof manifest.global, "boolean");
-  assert.ok(manifest.global);
   assert.strictEqual(typeof hash, "string");
   assert.ok(hash);
 

--- a/search-manifest/src/uploadToAtlas/uploadManifest.ts
+++ b/search-manifest/src/uploadToAtlas/uploadManifest.ts
@@ -62,7 +62,7 @@ export const uploadManifest = async (
 ) => {
   //check that manifest documents exist
   if (!manifest?.documents?.length) {
-    return Promise.reject(new Error("Invalid manifest "));
+    return Promise.reject(new Error("Invalid manifest"));
   }
   //get searchProperty, url
   //TODO: pass in a db session
@@ -102,6 +102,7 @@ export const uploadManifest = async (
   //check property types
 
   console.info(`Starting transaction`);
+  console.log(manifest.global);
   assert.strictEqual(typeof manifest.global, "boolean");
   assert.ok(manifest.global);
   assert.strictEqual(typeof hash, "string");

--- a/search-manifest/src/uploadToAtlas/uploadManifest.ts
+++ b/search-manifest/src/uploadToAtlas/uploadManifest.ts
@@ -40,7 +40,7 @@ const composeUpserts = async (
       url: joinUrl(manifest.url, document.slug),
       manifestRevisionId: hash,
       searchProperty: [searchProperty],
-      includeInGlobalSearch: manifest.global,
+      includeInGlobalSearch: manifest.global ?? false,
     };
 
     return {

--- a/search-manifest/src/uploadToAtlas/uploadManifest.ts
+++ b/search-manifest/src/uploadToAtlas/uploadManifest.ts
@@ -102,10 +102,10 @@ export const uploadManifest = async (
   //check property types
 
   console.info(`Starting transaction`);
-  console.log(manifest.global);
-  assert.strictEqual(typeof manifest.global, "boolean");
-  assert.strictEqual(typeof hash, "string");
-  assert.ok(hash);
+  console.log("global value:", manifest.global, typeof manifest.global);
+  // assert.strictEqual(typeof manifest.global, "boolean");
+  // assert.strictEqual(typeof hash, "string");
+  // assert.ok(hash);
 
   if (operations.length > 0) {
     const bulkWriteStatus = await documentsColl?.bulkWrite(operations, {

--- a/search-manifest/src/uploadToAtlas/uploadManifest.ts
+++ b/search-manifest/src/uploadToAtlas/uploadManifest.ts
@@ -64,9 +64,6 @@ export const uploadManifest = async (
   if (!manifest?.documents?.length) {
     return Promise.reject(new Error("Invalid manifest"));
   }
-  //get searchProperty, url
-  //TODO: pass in a db session
-
   //start a session
   let documentsColl;
   try {

--- a/search-manifest/src/uploadToAtlas/uploadManifest.ts
+++ b/search-manifest/src/uploadToAtlas/uploadManifest.ts
@@ -1,5 +1,5 @@
 import { Manifest } from "../generateManifest/manifest";
-import { db } from "./searchConnector";
+import { db, teardown } from "./searchConnector";
 import assert from "assert";
 import { RefreshInfo, DatabaseDocument } from "./types";
 import { generateHash, joinUrl } from "./utils";
@@ -110,5 +110,6 @@ export const uploadManifest = async (
     status.deleted += bulkWriteStatus?.deletedCount ?? 0;
     status.upserted += bulkWriteStatus?.upsertedCount ?? 0;
   }
+  teardown();
   return status;
 };

--- a/search-manifest/src/uploadToAtlas/utils.ts
+++ b/search-manifest/src/uploadToAtlas/utils.ts
@@ -19,3 +19,7 @@ export function generateHash(data: string): Promise<string> {
 export function joinUrl(base: string, path: string): string {
   return base.replace(/\/*$/, "/") + path.replace(/^\/*/, "");
 }
+
+export function assertTrailingSlash(path: string): string {
+  return path.endsWith("/") ? path : `${path}/`;
+}

--- a/search-manifest/src/uploadToAtlas/utils.ts
+++ b/search-manifest/src/uploadToAtlas/utils.ts
@@ -17,6 +17,5 @@ export function generateHash(data: string): Promise<string> {
 }
 
 export function joinUrl(base: string, path: string): string {
-  console.log("base", base);
   return base.replace(/\/*$/, "/") + path.replace(/^\/*/, "");
 }

--- a/search-manifest/src/uploadToAtlas/utils.ts
+++ b/search-manifest/src/uploadToAtlas/utils.ts
@@ -17,5 +17,6 @@ export function generateHash(data: string): Promise<string> {
 }
 
 export function joinUrl(base: string, path: string): string {
+  console.log("base", base);
   return base.replace(/\/*$/, "/") + path.replace(/^\/*/, "");
 }

--- a/search-manifest/tests/integration/uploadManifest.test.ts
+++ b/search-manifest/tests/integration/uploadManifest.test.ts
@@ -10,7 +10,7 @@ import {
 import { uploadManifest } from "../../src/uploadToAtlas/uploadManifest";
 import { Manifest } from "../../src/generateManifest/manifest";
 import nodeManifest from "../resources/s3Manifests/node-current.json";
-import { mockDb } from "../utils/mockDb";
+import { mockDb } from "../utils/mockDB";
 import { DatabaseDocument } from "../../src/uploadToAtlas/types";
 import { getManifest } from "../utils/getManifest";
 
@@ -19,7 +19,7 @@ const PROPERTY_NAME = "dummyName";
 //teardown connections
 beforeEach(async () => {
   vi.mock("../../src/uploadToAtlas/searchConnector", async () => {
-    const { mockDb, teardownMockDbClient } = await import("../utils/mockDb");
+    const { mockDb, teardownMockDbClient } = await import("../utils/mockDB");
     return {
       teardown: teardownMockDbClient,
       db: async () => {
@@ -49,7 +49,7 @@ const removeDocuments = async () => {
 
 afterAll(async () => {
   //teardown db instance
-  const { teardownMockDbClient } = await import("../utils/mockDb");
+  const { teardownMockDbClient } = await import("../utils/mockDB");
   await teardownMockDbClient();
 });
 

--- a/search-manifest/tests/integration/uploadManifest.test.ts
+++ b/search-manifest/tests/integration/uploadManifest.test.ts
@@ -65,7 +65,7 @@ describe("Upload manifest doesn't work for invalid manifests", () => {
   });
 
   test("throws an error for a manifest with 0 documents", async () => {
-    manifest = new Manifest(true);
+    manifest = new Manifest("", true);
     expect(
       async () => await uploadManifest(manifest, PROPERTY_NAME)
     ).rejects.toThrowError();
@@ -84,8 +84,8 @@ describe("Upload manifest uploads to Atlas db", () => {
 
   test("constant nodeManifest uploads correct number of documents", async () => {
     manifest = new Manifest(
-      nodeManifest.includeInGlobalSearch,
-      nodeManifest.url
+      nodeManifest.url,
+      nodeManifest.includeInGlobalSearch
     );
     manifest.documents = nodeManifest.documents;
 
@@ -115,8 +115,8 @@ describe("Upload manifest uploads to Atlas db", () => {
 
 describe("Upload manifest uploads to Atlas db and updates existing manifests correctly ", async () => {
   let manifest1: Manifest = new Manifest(
-    nodeManifest.includeInGlobalSearch,
-    nodeManifest.url
+    nodeManifest.url,
+    nodeManifest.includeInGlobalSearch
   );
   manifest1.documents = nodeManifest.documents;
 

--- a/search-manifest/tests/integration/uploadManifest.test.ts
+++ b/search-manifest/tests/integration/uploadManifest.test.ts
@@ -10,7 +10,7 @@ import {
 import { uploadManifest } from "../../src/uploadToAtlas/uploadManifest";
 import { Manifest } from "../../src/generateManifest/manifest";
 import nodeManifest from "../resources/s3Manifests/node-current.json";
-import { mockDb } from "../utils/mockDB";
+import { mockDb, removeDocuments } from "../utils/mockDB";
 import { DatabaseDocument } from "../../src/uploadToAtlas/types";
 import { getManifest } from "../utils/getManifest";
 
@@ -36,15 +36,6 @@ const checkCollection = async () => {
     .collection<DatabaseDocument>("documents")
     .estimatedDocumentCount();
   expect(documentCount).toEqual(0);
-};
-
-const removeDocuments = async () => {
-  //delete all documents in repo
-  const db = await mockDb();
-  await db.collection<DatabaseDocument>("documents").deleteMany({});
-  const documentCount = await db
-    .collection<DatabaseDocument>("documents")
-    .estimatedDocumentCount();
 };
 
 afterAll(async () => {
@@ -74,7 +65,7 @@ describe("Upload manifest doesn't work for invalid manifests", () => {
 // given manifests, test that it uploads said manifests
 describe("Upload manifest uploads to Atlas db", () => {
   afterEach(async () => {
-    await removeDocuments();
+    await removeDocuments("documents");
   });
   let manifest: Manifest;
 

--- a/search-manifest/tests/integration/uploadManifest.test.ts
+++ b/search-manifest/tests/integration/uploadManifest.test.ts
@@ -10,7 +10,7 @@ import {
 import { uploadManifest } from "../../src/uploadToAtlas/uploadManifest";
 import { Manifest } from "../../src/generateManifest/manifest";
 import nodeManifest from "../resources/s3Manifests/node-current.json";
-import { mockDb } from "../utils/mockDB";
+import { mockDb } from "../utils/mockDb";
 import { DatabaseDocument } from "../../src/uploadToAtlas/types";
 import { getManifest } from "../utils/getManifest";
 
@@ -19,7 +19,7 @@ const PROPERTY_NAME = "dummyName";
 //teardown connections
 beforeEach(async () => {
   vi.mock("../../src/uploadToAtlas/searchConnector", async () => {
-    const { mockDb, teardownMockDbClient } = await import("../utils/mockDB");
+    const { mockDb, teardownMockDbClient } = await import("../utils/mockDb");
 
     return {
       teardown: teardownMockDbClient,
@@ -50,7 +50,7 @@ const removeDocuments = async () => {
 
 afterAll(async () => {
   //teardown db instance
-  const { teardownMockDbClient } = await import("../utils/mockDB");
+  const { teardownMockDbClient } = await import("../utils/mockDb");
   await teardownMockDbClient();
 });
 
@@ -87,6 +87,7 @@ describe("Upload manifest uploads to Atlas db", () => {
       nodeManifest.url,
       nodeManifest.includeInGlobalSearch
     );
+    console.log;
     manifest.documents = nodeManifest.documents;
 
     const status = await uploadManifest(manifest, PROPERTY_NAME);

--- a/search-manifest/tests/integration/uploadManifest.test.ts
+++ b/search-manifest/tests/integration/uploadManifest.test.ts
@@ -73,9 +73,6 @@ describe("Upload manifest doesn't work for invalid manifests", () => {
 
 // given manifests, test that it uploads said manifests
 describe("Upload manifest uploads to Atlas db", () => {
-  beforeEach(async () => {
-    await checkCollection();
-  });
   afterEach(async () => {
     await removeDocuments();
   });
@@ -86,7 +83,6 @@ describe("Upload manifest uploads to Atlas db", () => {
       nodeManifest.url,
       nodeManifest.includeInGlobalSearch
     );
-    console.log;
     manifest.documents = nodeManifest.documents;
 
     await uploadManifest(manifest, PROPERTY_NAME);
@@ -94,7 +90,6 @@ describe("Upload manifest uploads to Atlas db", () => {
     //check that manifests have been uploaded
     const db = await mockDb();
     const documents = db.collection<DatabaseDocument>("documents");
-    console.log(db);
     //count number of documents in collection
     expect(await documents.countDocuments()).toEqual(manifest.documents.length);
   });

--- a/search-manifest/tests/resources/mockCollections/docsets.json
+++ b/search-manifest/tests/resources/mockCollections/docsets.json
@@ -1,0 +1,51 @@
+[
+    {
+        "project": "atlas-app-services",
+        "prefix": {
+            "stg": "atlas/app-services",
+            "prd": "atlas/app-services",
+            "dotcomstg": "docs/atlas/app-services",
+            "dotcomprd": "docs/atlas/app-services"
+        },
+        "url": {
+            "dev": "https://docs-atlas-staging.mongodb.com",
+            "stg": "https://docs-atlas-staging.mongodb.com",
+            "prd": "https://docs.atlas.mongodb.com",
+            "dotcomprd": "http://mongodb.com/",
+            "dotcomstg": "https://mongodbcom-cdn.website.staging.corp.mongodb.com/"
+        }
+    },
+    {
+        "project": "compass",
+        "prefix": {
+            "stg": "compass",
+            "prd": "compass",
+            "dotcomstg": "docs/compass",
+            "dotcomprd": "docs/compass"
+        },
+        "url": {
+            "dev": "https://docs-mongodborg-staging.corp.mongodb.com",
+            "stg": "https://docs-mongodborg-staging.corp.mongodb.com",
+            "prd": "https://docs.mongodb.com",
+            "dotcomprd": "http://mongodb.com/",
+            "dotcomstg": "https://mongodbcom-cdn.website.staging.corp.mongodb.com/"
+        }
+    },
+    {
+        "project": "cloud-docs",
+        "prefix": {
+            "stg": "",
+            "prd": "",
+            "dotcomstg": "docs/atlas",
+            "dotcomprd": "docs/atlas"
+        },
+        "url": {
+            "dev": "https://docs-atlas-staging.mongodb.com",
+            "stg": "https://docs-atlas-staging.mongodb.com",
+            "prd": "https://docs.atlas.mongodb.com",
+            "dotcomprd": "http://mongodb.com/",
+            "dotcomstg": "https://mongodbcom-cdn.website.staging.corp.mongodb.com/"
+        }
+    }
+
+]

--- a/search-manifest/tests/resources/mockCollections/repos-branches.json
+++ b/search-manifest/tests/resources/mockCollections/repos-branches.json
@@ -1,0 +1,51 @@
+
+[ {
+        "repoName": "docs-app-services",
+        "branches": [{
+            "gitBranchName": "master",
+            "urlSlug" : "",
+            "isStableBranch": "true"
+        }],
+        "project": "atlas-app-services",
+        "internalOnly": false, 
+        "prodDeployable": true
+    },
+    {
+        "repoName": "docs-compass",
+        "branches": [
+            {
+                "gitBranchName": "master",
+                "isStableBranch": true,
+                "urlSlug": "current"
+            },
+            {
+                "gitBranchName": "beta", 
+                "urlSlug": "upcoming",
+                "isStableBranch": false
+            }
+        ],
+        "project": "compass",
+        "search": {
+            "categoryTitle": "Compass"
+        },
+        "internalOnly": false,
+        "prodDeployable": true
+    },
+    {
+        "repo_name": "cloud-docs",
+        "branches": [
+            {
+                "gitBranchName": "master",
+                "urlSlug": "",
+                "isStableBranch": true
+            }
+        ],
+        "search": {
+            "categoryName": "atlas",
+            "categoryTitle": "Atlas"
+        },
+        "internalOnly": false,
+        "prodDeployable": false
+    }
+]
+

--- a/search-manifest/tests/resources/mockCollections/repos-branches.json
+++ b/search-manifest/tests/resources/mockCollections/repos-branches.json
@@ -32,7 +32,7 @@
         "prodDeployable": true
     },
     {
-        "repo_name": "cloud-docs",
+        "repoName": "cloud-docs",
         "branches": [
             {
                 "gitBranchName": "master",
@@ -40,12 +40,13 @@
                 "isStableBranch": true
             }
         ],
+        "project": "cloud-docs",
         "search": {
             "categoryName": "atlas",
             "categoryTitle": "Atlas"
         },
         "internalOnly": false,
-        "prodDeployable": false
+        "prodDeployable": true
     }
 ]
 

--- a/search-manifest/tests/snapshots/index.test.ts
+++ b/search-manifest/tests/snapshots/index.test.ts
@@ -1,5 +1,5 @@
-// snapshot tests
-import { describe, expect, test, it, vi } from "vitest";
+// TODO: snapshot tests
+import { describe, expect, test } from "vitest";
 
 function sum(a: number, b: number) {
   return a + b;

--- a/search-manifest/tests/unit/getProperties.test.ts
+++ b/search-manifest/tests/unit/getProperties.test.ts
@@ -11,7 +11,7 @@ import {
   getProperties,
   getBranch,
 } from "../../src/uploadToAtlas/getProperties";
-import { mockDb, teardownMockDbClient, insert } from "../utils/mockDb";
+import { mockDb, teardownMockDbClient, insert } from "../utils/mockDB";
 // simulate the repos_branches collection in an object
 import repos_branches from "../resources/mockCollections/repos-branches.json";
 //simulate the docsests collection in an object
@@ -44,7 +44,7 @@ const removeDocuments = async () => {
 //mock repos_branches database
 beforeEach(async () => {
   vi.mock("../../src/uploadToAtlas/searchConnector", async () => {
-    const { mockDb, teardownMockDbClient } = await import("../utils/mockDb");
+    const { mockDb, teardownMockDbClient } = await import("../utils/mockDB");
     return {
       teardown: teardownMockDbClient,
       db: async () => {

--- a/search-manifest/tests/unit/getProperties.test.ts
+++ b/search-manifest/tests/unit/getProperties.test.ts
@@ -44,10 +44,9 @@ const removeDocuments = async () => {
 //mock repos_branches database
 beforeEach(async () => {
   vi.mock("../../src/uploadToAtlas/searchConnector", async () => {
-    const { mockDb, teardownMockDbClient, insert } = await import(
-      "../utils/mockDb"
-    );
+    const { mockDb, teardownMockDbClient } = await import("../utils/mockDb");
     return {
+      teardown: teardownMockDbClient,
       db: async () => {
         //create mock db of repos_branches. populate it with the repos branches object, docsets obj defined here
         const db = await mockDb();
@@ -112,7 +111,6 @@ describe("Given a branchname, get the properties associated with it from repos_b
 
   test(`correct properties are retrieved for branch ${BRANCH_NAME_BETA} of repoName ${repoNames[0]}`, async () => {
     //define expected properties object for beta branch of Compass repo
-
     process.env.REPO_NAME = repoNames[0];
     const compassBetaProperties = {
       searchProperty: "compass-upcoming",
@@ -127,7 +125,6 @@ describe("Given a branchname, get the properties associated with it from repos_b
 
   test(`correct properties are retrieved for branch ${BRANCH_NAME_MASTER} of repoName ${repoNames[1]}`, async () => {
     //define expected properties object for master branch of cloud-docs repo
-
     process.env.REPO_NAME = repoNames[1];
     const cloudDocsMasterProperties = {
       searchProperty: "cloud-docs-master",

--- a/search-manifest/tests/unit/getProperties.test.ts
+++ b/search-manifest/tests/unit/getProperties.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test, it, vi } from "vitest";
+
+function sum(a: number, b: number) {
+  return a + b;
+}
+test("adds 1 + 2 to equal 3", () => {
+  expect(sum(1, 2)).toBe(3);
+});

--- a/search-manifest/tests/unit/getProperties.test.ts
+++ b/search-manifest/tests/unit/getProperties.test.ts
@@ -1,8 +1,68 @@
-import { describe, expect, test, it, vi } from "vitest";
+import { describe, beforeEach, expect, test, it, vi } from "vitest";
+import {
+  getProperties,
+  getBranch,
+} from "../../src/uploadToAtlas/getProperties";
+import { mockDb } from "../utils/mockDB";
+// simulate the repos_branches collection in an object
+// TODO: add another one branch one that DOES have a search object}
+import repos_branches from "../resources/mockCollections/repos-branches.json";
+//simulate the docsests collection in an object
+import docsets from "../resources/mockCollections/docsets.json";
 
-function sum(a: number, b: number) {
-  return a + b;
-}
-test("adds 1 + 2 to equal 3", () => {
-  expect(sum(1, 2)).toBe(3);
+const BRANCH_NAME_MASTER = "master";
+const BRANCH_NAME_V1 = "v1.0";
+const BRANCH_NAME_GIBBERISH = "gibberish";
+
+const repoName = "";
+
+//mock repos_branches database
+beforeEach(async () => {
+  vi.mock("../../src/uploadToAtlas/searchConnector", async () => {
+    const { mockDb, teardownMockDbClient } = await import("../utils/mockDB");
+
+    return {
+      teardown: teardownMockDbClient,
+      db: async () => {
+        //create mock db of repos_branches. populate it with the repos branches object, docsets obj defined here
+        const db = "";
+        return db;
+      },
+    };
+  });
+});
+
+describe("given an array of branches and a branch name, the corrct output is returned", () => {
+  //mock branches object
+  const branches: any = [];
+  test("given a branch name that exists in the branches array, the correct branch object is returned", () => {
+    expect(getBranch(branches, BRANCH_NAME_MASTER)).toEqual({});
+  });
+  test("given a branch name that exists with different capitalization than in the branches array, the correct branch object is still returned", () => {
+    expect(getBranch(branches, "MASTER")).toEqual({});
+  });
+  test("given a branch name that doesn't exist in the branches array, an error is thrown", () => {
+    expect(getBranch(branches, BRANCH_NAME_GIBBERISH)).toThrowError(
+      `Current branch ${BRANCH_NAME_GIBBERISH} not found in repos branches entry`
+    );
+  });
+  test("given a branch name and an empty branches array, an error is thrown", () => {
+    expect(getBranch([], BRANCH_NAME_MASTER)).toThrowError(
+      `Current branch ${BRANCH_NAME_MASTER} not found in repos branches entry`
+    );
+  });
+});
+
+//TODO: add another repoName and another test for it
+//two tests for a repo with multiple branches, one test for a repo with only one branch
+describe("Given a branchname, get the properties associated with it from repos_branches", () => {
+  //mock repo name
+  test(`correct properties are retrieved for branch ${BRANCH_NAME_MASTER} of repoName ${repoName}`, () => {
+    //define expected properties object
+    expect(getProperties(BRANCH_NAME_MASTER)).toEqual({});
+  });
+  test(`correct properties are retrieved for branch ${BRANCH_NAME_V1} of repoName ${repoName}`, () => {
+    //define expected properties object
+    expect(getProperties(BRANCH_NAME_MASTER)).toEqual({});
+  });
 });

--- a/search-manifest/tests/unit/getProperties.test.ts
+++ b/search-manifest/tests/unit/getProperties.test.ts
@@ -7,9 +7,8 @@ import {
   beforeAll,
   afterAll,
 } from "vitest";
-import {
-  getProperties,
-  getBranch,
+import getProperties, {
+  _getBranch,
 } from "../../src/uploadToAtlas/getProperties";
 import { mockDb, teardownMockDbClient, insert } from "../utils/mockDB";
 // simulate the repos_branches collection in an object
@@ -66,7 +65,7 @@ describe("given an array of branches and a branch name, the corrct output is ret
   //mock branches object
   const branches: any = repos_branches[1].branches;
   test("given a branch name that exists in the branches array, the correct branch object is returned", () => {
-    expect(getBranch(branches, BRANCH_NAME_MASTER)).toEqual({
+    expect(_getBranch(branches, BRANCH_NAME_MASTER)).toEqual({
       gitBranchName: "master",
       isStableBranch: true,
       urlSlug: "current",
@@ -74,22 +73,18 @@ describe("given an array of branches and a branch name, the corrct output is ret
   });
 
   test("given a branch name that exists with different capitalization than in the branches array, the correct branch object is still returned", () => {
-    expect(getBranch(branches, "MASTER")).toEqual({
+    expect(_getBranch(branches, "MASTER")).toEqual({
       gitBranchName: "master",
       isStableBranch: true,
       urlSlug: "current",
     });
   });
 
-  test("given a branch name that doesn't exist in the branches array, an error is thrown", () => {
-    expect(() => getBranch(branches, BRANCH_NAME_GIBBERISH)).toThrow(
-      `Current branch ${BRANCH_NAME_GIBBERISH} not found in repos branches entry`
-    );
+  test("given a branch name that doesn't exist in the branches array, undefined is returned", () => {
+    expect(_getBranch(branches, BRANCH_NAME_GIBBERISH)).toEqual(undefined);
   });
-  test("given a branch name and an empty branches array, an error is thrown", () => {
-    expect(() => getBranch([], BRANCH_NAME_MASTER)).toThrow(
-      `Current branch ${BRANCH_NAME_MASTER} not found in repos branches entry`
-    );
+  test("given a branch name and an empty branches array, undefined is returned", () => {
+    expect(_getBranch([], BRANCH_NAME_MASTER)).toEqual(undefined);
   });
 });
 
@@ -101,7 +96,7 @@ describe("Given a branchname, get the properties associated with it from repos_b
     process.env.REPO_NAME = repoNames[0];
     const compassMasterProperties = {
       searchProperty: "compass-current",
-      url: "http://mongodb.com/docs/compass",
+      url: "http://mongodb.com/docs/compass/",
       includeInGlobalSearch: true,
     };
     expect(await getProperties(BRANCH_NAME_MASTER)).toEqual(
@@ -114,7 +109,7 @@ describe("Given a branchname, get the properties associated with it from repos_b
     process.env.REPO_NAME = repoNames[0];
     const compassBetaProperties = {
       searchProperty: "compass-upcoming",
-      url: "http://mongodb.com/docs/compass",
+      url: "http://mongodb.com/docs/compass/",
       includeInGlobalSearch: false,
     };
 
@@ -127,8 +122,8 @@ describe("Given a branchname, get the properties associated with it from repos_b
     //define expected properties object for master branch of cloud-docs repo
     process.env.REPO_NAME = repoNames[1];
     const cloudDocsMasterProperties = {
-      searchProperty: "cloud-docs-master",
-      url: "http://mongodb.com/docs/atlas",
+      searchProperty: "atlas-master",
+      url: "http://mongodb.com/docs/atlas/",
       includeInGlobalSearch: true,
     };
 

--- a/search-manifest/tests/unit/getProperties.test.ts
+++ b/search-manifest/tests/unit/getProperties.test.ts
@@ -10,35 +10,31 @@ import {
 import getProperties, {
   _getBranch,
 } from "../../src/uploadToAtlas/getProperties";
-import { mockDb, teardownMockDbClient, insert } from "../utils/mockDB";
+import {
+  mockDb,
+  teardownMockDbClient,
+  insert,
+  removeDocuments,
+} from "../utils/mockDB";
 // simulate the repos_branches collection in an object
 import repos_branches from "../resources/mockCollections/repos-branches.json";
 //simulate the docsests collection in an object
 import docsets from "../resources/mockCollections/docsets.json";
-import { DatabaseDocument } from "../../src/uploadToAtlas/types";
 
 const BRANCH_NAME_MASTER = "master";
 const BRANCH_NAME_BETA = "beta";
 const BRANCH_NAME_GIBBERISH = "gibberish";
 
-const repoNames = ["docs-compass", "cloud-docs", "docs-app-services"];
+const DOCS_COMPASS_NAME = "docs-compass";
+const DOCS_CLOUD_NAME = "cloud-docs";
+const DOCS_APP_SERVICES_NAME = "docs-app-services";
 
 beforeAll(async () => {
-  process.env.REPO_NAME = repoNames[0];
+  process.env.REPO_NAME = DOCS_COMPASS_NAME;
   const db = await mockDb();
   await insert(db, "repos_branches", repos_branches);
   await insert(db, "docsets", docsets);
 });
-
-const removeDocuments = async () => {
-  //delete all documents in repo
-  const db = await mockDb();
-  await db.collection<DatabaseDocument>("repos_branches").deleteMany({});
-  const documentCount = await db
-    .collection<DatabaseDocument>("repos_branches")
-    .estimatedDocumentCount();
-  return documentCount;
-};
 
 //mock repos_branches database
 beforeEach(async () => {
@@ -57,7 +53,7 @@ beforeEach(async () => {
 
 afterAll(async () => {
   //teardown db instance
-  await removeDocuments();
+  await removeDocuments("repos_branches");
   await teardownMockDbClient();
 });
 
@@ -91,9 +87,9 @@ describe("given an array of branches and a branch name, the corrct output is ret
 //two tests for a repo with multiple branches, one test for a repo with only one branch
 describe("Given a branchname, get the properties associated with it from repos_branches", () => {
   //mock repo name
-  test(`correct properties are retrieved for branch ${BRANCH_NAME_MASTER} of repoName ${repoNames[0]}`, async () => {
+  test(`correct properties are retrieved for branch ${BRANCH_NAME_MASTER} of repoName ${DOCS_COMPASS_NAME}`, async () => {
     //define expected properties object for master branch of Compass repo
-    process.env.REPO_NAME = repoNames[0];
+    process.env.REPO_NAME = DOCS_COMPASS_NAME;
     const compassMasterProperties = {
       searchProperty: "compass-current",
       url: "http://mongodb.com/docs/compass/",
@@ -104,9 +100,9 @@ describe("Given a branchname, get the properties associated with it from repos_b
     );
   });
 
-  test(`correct properties are retrieved for branch ${BRANCH_NAME_BETA} of repoName ${repoNames[0]}`, async () => {
+  test(`correct properties are retrieved for branch ${BRANCH_NAME_BETA} of repoName ${DOCS_COMPASS_NAME}`, async () => {
     //define expected properties object for beta branch of Compass repo
-    process.env.REPO_NAME = repoNames[0];
+    process.env.REPO_NAME = DOCS_COMPASS_NAME;
     const compassBetaProperties = {
       searchProperty: "compass-upcoming",
       url: "http://mongodb.com/docs/compass/",
@@ -118,9 +114,9 @@ describe("Given a branchname, get the properties associated with it from repos_b
     );
   });
 
-  test(`correct properties are retrieved for branch ${BRANCH_NAME_MASTER} of repoName ${repoNames[1]}`, async () => {
+  test(`correct properties are retrieved for branch ${BRANCH_NAME_MASTER} of repoName ${DOCS_CLOUD_NAME}`, async () => {
     //define expected properties object for master branch of cloud-docs repo
-    process.env.REPO_NAME = repoNames[1];
+    process.env.REPO_NAME = DOCS_CLOUD_NAME;
     const cloudDocsMasterProperties = {
       searchProperty: "atlas-master",
       url: "http://mongodb.com/docs/atlas/",
@@ -132,9 +128,9 @@ describe("Given a branchname, get the properties associated with it from repos_b
     );
   });
 
-  test(`no properties are retrieved for branch on repo ${repoNames[2]} without a "search" field. `, async () => {
+  test(`no properties are retrieved for branch on repo ${DOCS_APP_SERVICES_NAME} without a "search" field. `, async () => {
     //define expected properties object for master branch of docs-app-services repo
-    process.env.REPO_NAME = repoNames[2];
+    process.env.REPO_NAME = DOCS_APP_SERVICES_NAME;
     await expect(getProperties(BRANCH_NAME_MASTER)).rejects.toThrow();
   });
 });

--- a/search-manifest/tests/unit/getProperties.test.ts
+++ b/search-manifest/tests/unit/getProperties.test.ts
@@ -1,68 +1,148 @@
-import { describe, beforeEach, expect, test, it, vi } from "vitest";
+import {
+  describe,
+  beforeEach,
+  expect,
+  test,
+  vi,
+  beforeAll,
+  afterAll,
+} from "vitest";
 import {
   getProperties,
   getBranch,
 } from "../../src/uploadToAtlas/getProperties";
-import { mockDb } from "../utils/mockDB";
+import { mockDb, teardownMockDbClient, insert } from "../utils/mockDb";
 // simulate the repos_branches collection in an object
-// TODO: add another one branch one that DOES have a search object}
 import repos_branches from "../resources/mockCollections/repos-branches.json";
 //simulate the docsests collection in an object
 import docsets from "../resources/mockCollections/docsets.json";
+import { DatabaseDocument } from "../../src/uploadToAtlas/types";
 
 const BRANCH_NAME_MASTER = "master";
-const BRANCH_NAME_V1 = "v1.0";
+const BRANCH_NAME_BETA = "beta";
 const BRANCH_NAME_GIBBERISH = "gibberish";
 
-const repoName = "";
+const repoNames = ["docs-compass", "cloud-docs", "docs-app-services"];
+
+beforeAll(async () => {
+  process.env.REPO_NAME = repoNames[0];
+  const db = await mockDb();
+  await insert(db, "repos_branches", repos_branches);
+  await insert(db, "docsets", docsets);
+});
+
+const removeDocuments = async () => {
+  //delete all documents in repo
+  const db = await mockDb();
+  await db.collection<DatabaseDocument>("repos_branches").deleteMany({});
+  const documentCount = await db
+    .collection<DatabaseDocument>("repos_branches")
+    .estimatedDocumentCount();
+  return documentCount;
+};
 
 //mock repos_branches database
 beforeEach(async () => {
   vi.mock("../../src/uploadToAtlas/searchConnector", async () => {
-    const { mockDb, teardownMockDbClient } = await import("../utils/mockDB");
-
+    const { mockDb, teardownMockDbClient, insert } = await import(
+      "../utils/mockDb"
+    );
     return {
-      teardown: teardownMockDbClient,
       db: async () => {
         //create mock db of repos_branches. populate it with the repos branches object, docsets obj defined here
-        const db = "";
+        const db = await mockDb();
         return db;
       },
     };
   });
 });
 
+afterAll(async () => {
+  //teardown db instance
+  await removeDocuments();
+  await teardownMockDbClient();
+});
+
 describe("given an array of branches and a branch name, the corrct output is returned", () => {
   //mock branches object
-  const branches: any = [];
+  const branches: any = repos_branches[1].branches;
   test("given a branch name that exists in the branches array, the correct branch object is returned", () => {
-    expect(getBranch(branches, BRANCH_NAME_MASTER)).toEqual({});
+    expect(getBranch(branches, BRANCH_NAME_MASTER)).toEqual({
+      gitBranchName: "master",
+      isStableBranch: true,
+      urlSlug: "current",
+    });
   });
+
   test("given a branch name that exists with different capitalization than in the branches array, the correct branch object is still returned", () => {
-    expect(getBranch(branches, "MASTER")).toEqual({});
+    expect(getBranch(branches, "MASTER")).toEqual({
+      gitBranchName: "master",
+      isStableBranch: true,
+      urlSlug: "current",
+    });
   });
+
   test("given a branch name that doesn't exist in the branches array, an error is thrown", () => {
-    expect(getBranch(branches, BRANCH_NAME_GIBBERISH)).toThrowError(
+    expect(() => getBranch(branches, BRANCH_NAME_GIBBERISH)).toThrow(
       `Current branch ${BRANCH_NAME_GIBBERISH} not found in repos branches entry`
     );
   });
   test("given a branch name and an empty branches array, an error is thrown", () => {
-    expect(getBranch([], BRANCH_NAME_MASTER)).toThrowError(
+    expect(() => getBranch([], BRANCH_NAME_MASTER)).toThrow(
       `Current branch ${BRANCH_NAME_MASTER} not found in repos branches entry`
     );
   });
 });
 
-//TODO: add another repoName and another test for it
 //two tests for a repo with multiple branches, one test for a repo with only one branch
 describe("Given a branchname, get the properties associated with it from repos_branches", () => {
   //mock repo name
-  test(`correct properties are retrieved for branch ${BRANCH_NAME_MASTER} of repoName ${repoName}`, () => {
-    //define expected properties object
-    expect(getProperties(BRANCH_NAME_MASTER)).toEqual({});
+  test(`correct properties are retrieved for branch ${BRANCH_NAME_MASTER} of repoName ${repoNames[0]}`, async () => {
+    //define expected properties object for master branch of Compass repo
+    process.env.REPO_NAME = repoNames[0];
+    const compassMasterProperties = {
+      searchProperty: "compass-current",
+      url: "http://mongodb.com/docs/compass",
+      includeInGlobalSearch: true,
+    };
+    expect(await getProperties(BRANCH_NAME_MASTER)).toEqual(
+      compassMasterProperties
+    );
   });
-  test(`correct properties are retrieved for branch ${BRANCH_NAME_V1} of repoName ${repoName}`, () => {
-    //define expected properties object
-    expect(getProperties(BRANCH_NAME_MASTER)).toEqual({});
+
+  test(`correct properties are retrieved for branch ${BRANCH_NAME_BETA} of repoName ${repoNames[0]}`, async () => {
+    //define expected properties object for beta branch of Compass repo
+
+    process.env.REPO_NAME = repoNames[0];
+    const compassBetaProperties = {
+      searchProperty: "compass-upcoming",
+      url: "http://mongodb.com/docs/compass",
+      includeInGlobalSearch: false,
+    };
+
+    expect(await getProperties(BRANCH_NAME_BETA)).toEqual(
+      compassBetaProperties
+    );
+  });
+
+  test(`correct properties are retrieved for branch ${BRANCH_NAME_MASTER} of repoName ${repoNames[1]}`, async () => {
+    //define expected properties object for master branch of cloud-docs repo
+
+    process.env.REPO_NAME = repoNames[1];
+    const cloudDocsMasterProperties = {
+      searchProperty: "cloud-docs-master",
+      url: "http://mongodb.com/docs/atlas",
+      includeInGlobalSearch: true,
+    };
+
+    expect(await getProperties(BRANCH_NAME_MASTER)).toEqual(
+      cloudDocsMasterProperties
+    );
+  });
+
+  test(`no properties are retrieved for branch on repo ${repoNames[2]} without a "search" field. `, async () => {
+    //define expected properties object for master branch of docs-app-services repo
+    process.env.REPO_NAME = repoNames[2];
+    await expect(getProperties(BRANCH_NAME_MASTER)).rejects.toThrow();
   });
 });

--- a/search-manifest/tests/unit/index.test.ts
+++ b/search-manifest/tests/unit/index.test.ts
@@ -62,7 +62,7 @@ describe.each([
       //code
       expect(manifest.documents[0].code).toEqual(equivDoc.code);
     });
-    //preview FAILS
+    //preview
     it("matches preview", () => {
       expect(manifest.documents[0].preview).toEqual(equivDoc.preview);
     });

--- a/search-manifest/tests/unit/index.test.ts
+++ b/search-manifest/tests/unit/index.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, afterEach, test, it, vi, beforeAll } from "vitest";
-import { generateManifest } from "../../src";
 import nodeManifest from "../resources/s3Manifests/node-current.json";
 import kotlinManifest from "../resources/s3Manifests/kotlin-upcoming.json";
-import * as fs from "fs";
-import { Manifest } from "../../src/generateManifest/manifest";
 import { ManifestEntry } from "../../src/generateManifest/manifestEntry";
 import { getManifest } from "../utils/getManifest";
 
@@ -21,11 +18,6 @@ describe.each([
   it("has the correct document length", () => {
     expect(manifest.documents).toHaveLength(s3Manifest.documents.length);
   });
-
-  it("has the correct includeInGlobalSearch value"),
-    () => {
-      expect(manifest.global).toEqual(s3Manifest.includeInGlobalSearch);
-    };
 });
 
 describe.each([

--- a/search-manifest/tests/utils/mockDB.ts
+++ b/search-manifest/tests/utils/mockDB.ts
@@ -1,5 +1,6 @@
 import { MongoMemoryServer } from "mongodb-memory-server";
 import * as mongodb from "mongodb";
+import { DatabaseDocument } from "../../src/uploadToAtlas/types";
 
 let client: mongodb.MongoClient;
 
@@ -29,4 +30,14 @@ export const insert = async (
   const coll = dbName.collection(collectionName);
   const result = await coll.insertMany(docs);
   console.log(`${result.insertedCount} documents were inserted`);
+};
+
+export const removeDocuments = async (collectionName: string) => {
+  //delete all documents in repo
+  const db = await mockDb();
+  await db.collection<DatabaseDocument>(collectionName).deleteMany({});
+  const documentCount = await db
+    .collection<DatabaseDocument>("documents")
+    .countDocuments();
+  return documentCount;
 };

--- a/search-manifest/tests/utils/mockDB.ts
+++ b/search-manifest/tests/utils/mockDB.ts
@@ -5,19 +5,28 @@ let client: mongodb.MongoClient;
 
 export async function teardownMockDbClient() {
   if (!client) return;
-
   await client.close();
 }
 
 export async function mockDb(): Promise<mongodb.Db> {
   if (client) {
     await client.connect();
-    return client.db("test_db");
+    return client.db("dummy_db");
   }
   const mongod = await MongoMemoryServer.create();
   const uri = mongod.getUri();
   client = new mongodb.MongoClient(uri);
   await client.connect();
-  const dbInstance = client.db("test_db");
+  const dbInstance = client.db("dummy_db");
   return dbInstance;
 }
+
+export const insert = async (
+  dbName: mongodb.Db,
+  collectionName: string,
+  docs: any[]
+) => {
+  const coll = dbName.collection(collectionName);
+  const result = await coll.insertMany(docs);
+  console.log(`${result.insertedCount} documents were inserted`);
+};


### PR DESCRIPTION
This PR updates the Search Manifest Integration developed for Netlify.

Key changes:
- gets the branch object from the site's repo entry in pool.repos_branches
- includeInGlobalSearch field is now properly set (`true` if the branch is the stable branch, `false` otherwise)
- accurately sets the searchProperty field as `<project> - <version>`
- checks that the repo is prodDeployable, it has a search Category Title field, and the repo is not set to internalOnly
- adds some error handling
- data added from repos_branches and docsets collections to mock them